### PR TITLE
Added ACL and ContentDisposition options to s3 put method

### DIFF
--- a/lib/drivers/s3Storage.ts
+++ b/lib/drivers/s3Storage.ts
@@ -43,12 +43,14 @@ export class S3Storage implements StorageDriver {
     fileContent: any,
     options?: FileOptions
   ): Promise<StorageDriver$PutFileResponse> {
-    const { mimeType } = options || {};
+    const { mimeType, ACL, ContentDisposition } = options || {};
     let params = {
       Bucket: this.config.bucket,
       Key: path,
       Body: fileContent,
       ContentType: mimeType ? mimeType : getMimeFromExtension(path),
+      ACL,
+      ContentDisposition,
     } as PutObjectRequest;
 
     const res = await this.client.upload(params).promise();

--- a/lib/interfaces/fileOptions.ts
+++ b/lib/interfaces/fileOptions.ts
@@ -1,3 +1,5 @@
 export interface FileOptions {
   mimeType?: string;
+  ACL?: string;
+  ContentDisposition?: string;
 }

--- a/lib/interfaces/storageDriver.ts
+++ b/lib/interfaces/storageDriver.ts
@@ -4,6 +4,7 @@ import {
   StorageDriver$PutFileResponse,
   StorageDriver$RenameFileResponse,
 } from ".";
+import { FileOptions } from "./fileOptions";
 
 export interface StorageDriver {
   /**
@@ -11,8 +12,13 @@ export interface StorageDriver {
    *
    * @param path
    * @param fileContent
+   * @param fileOptions
    */
-  put(path: string, fileContent: any): Promise<StorageDriver$PutFileResponse>;
+  put(
+    path: string,
+    fileContent: any,
+    fileOptions?: FileOptions
+  ): Promise<StorageDriver$PutFileResponse>;
 
   /**
    * Get file stored at the specified path.


### PR DESCRIPTION
This package may not work well with s3 buckets that are not publicly accessible unless user found a way to manually set the file permission to `public-read` which there is currently no way to set the uploading file permission from this package. That is why this Pull Request added the option to set the file options during upload.
cc @babygame0ver @vinayak25 

## Usage Example
```ts
Storage.disk('pictures').put(
  file.originalName,
  file.buffer,
  { ACL: 'public-read' },
)
```
